### PR TITLE
Handle enums in structs, handle scope resolution operator

### DIFF
--- a/ccc/ast.cpp
+++ b/ccc/ast.cpp
@@ -82,6 +82,11 @@ static TypeName resolve_c_type_name(const std::map<s32, const StabsType*>& types
 			name.array_indices.push_back(index->range_type.high + 1);
 			return name;
 		}
+		case StabsTypeDescriptor::ENUM: {
+			TypeName type_name;
+			type_name.first_part += "!!TYPE_NUMBER_" + std::to_string(type.type_number);
+			return type_name;
+		}
 		case StabsTypeDescriptor::FUNCTION: {
 			return {"/* function */ void*", {}};
 		}

--- a/ccc/ccc.h
+++ b/ccc/ccc.h
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <filesystem>
 #include <inttypes.h>
+#include <string>
 
 // *****************************************************************************
 // util.cpp

--- a/ccc/mdebug.cpp
+++ b/ccc/mdebug.cpp
@@ -1,31 +1,31 @@
 #include "ccc.h"
 
 packed_struct(SymbolicHeader,
-	s16 magic;
-	s16 vstamp;
-	s32 iline_max;
-	s32 cb_line;
-	s32 cb_line_offset;
-	s32 idn_max;
-	s32 cb_dn_offset;
-	s32 ipd_max;
-	s32 cb_pd_offset;
-	s32 isym_max;
-	s32 cb_sym_offset;
-	s32 iopt_max;
-	s32 cb_opt_offset;
-	s32 iaux_max;
-	s32 cb_aux_offset;
-	s32 iss_max;
-	s32 cb_ss_offset;
-	s32 iss_ext_max;
-	s32 cb_ss_ext_offset;
-	s32 ifd_max;
-	s32 cb_fd_offset;
-	s32 crfd;
-	s32 cb_rfd_offset;
-	s32 iext_max;
-	s32 cb_ext_offset;
+	s16 magic;            // 0x00
+	s16 vstamp;           // 0x02
+	s32 iline_max;        // 0x04
+	s32 cb_line;          // 0x08
+	s32 cb_line_offset;   // 0x0c
+	s32 idn_max;          // 0x10
+	s32 cb_dn_offset;     // 0x14
+	s32 ipd_max;          // 0x18
+	s32 cb_pd_offset;     // 0x1c
+	s32 isym_max;         // 0x20
+	s32 cb_sym_offset;    // 0x24
+	s32 iopt_max;         // 0x28
+	s32 cb_opt_offset;    // 0x2c
+	s32 iaux_max;         // 0x30
+	s32 cb_aux_offset;    // 0x34
+	s32 iss_max;          // 0x38
+	s32 cb_ss_offset;     // 0x3c
+	s32 iss_ext_max;      // 0x40
+	s32 cb_ss_ext_offset; // 0x44
+	s32 ifd_max;          // 0x48
+	s32 cb_fd_offset;     // 0x4c
+	s32 crfd;             // 0x50
+	s32 cb_rfd_offset;    // 0x54
+	s32 iext_max;         // 0x58
+	s32 cb_ext_offset;    // 0x5c
 )
 
 packed_struct(ProcedureDescriptorEntry,


### PR DESCRIPTION
It's been a while but hopefully I'm remembering this right.

Some enums are defined within structures, causing it to fail. This fixes that, but I'm not sure if it's fully fixed because it's been too long since I looked.

The scope resolution operator would also cause parsing to fail every time. This is very poorly handled now and needs to be updated, but basically it checks for a set of hardcoded strings and if those strings match, it reads it correctly. This was enough to parse types in the executables I care about, so I didn't pursue it further.

Also added some useful output for when it fails, which can definitely be improved upon.

I unfortunately can't split things into different PRs because I've forgotten what most things do (this is from a whole year ago at this point). Doesn't help that ccc contains essentially zero comments.

All in all this is a set of hacks, hopefully someone will find this and do better than me in fixing these issues.

If you want sample files to work with, refer to [Burnout Revenge (Jul 14, 2005 prototype)](https://hiddenpalace.org/Burnout_Revenge_(Jul_14,_2005_prototype)) and/or [Need for Speed: Most Wanted (Sep 20, 2005 prototype)](https://hiddenpalace.org/Need_for_Speed:_Most_Wanted_(Sep_20,_2005_prototype)), both of which have ELFs containing debug data which fails to parse using ccc. I'm sure there are others as well.